### PR TITLE
Make Ref.Raw() and Signature.Raw() return []byte, not string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+feeds.db


### PR DESCRIPTION
Pretty much that. The test doesn't pass but I see the same error on master so I don't think that's my fault.

Also I added feeds.db to .gitignore so there is no useless red line in every `git status`.

Edit: FWIW on both master and rawbytes the test error I see is 
```
feed_test.go:69: Error: expected previous %FMNFrlyeO5Z//fY5FbLVTNzhbqppGoLs0Bq4oR8450A=.sha256 but found %gmrb5/tjdgmHqMpZiyFL5T3uNUzKBOdv786WuamBybM=.sha256
```